### PR TITLE
Add GitHub Pages workflow to publish docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - run: rustup update
+    - uses: stellar/actions/rust-cache@main
+    - run: cargo doc --no-deps
+    - run: echo '<meta http-equiv="refresh" content="0; url=channel/index.html">' > target/doc/index.html
+    - uses: actions/upload-pages-artifact@v3
+      with:
+        path: target/doc
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - id: deployment
+      uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ fmt-check:
 	cargo fmt --all --check
 
 doc:
-	cargo doc --open
+	cargo doc --no-deps --open
 
 doc-check:
-	cargo doc
+	cargo doc --no-deps
 
 readme:
 	cd contracts/channel \


### PR DESCRIPTION
### What
Add a GitHub Actions workflow that builds Rust docs with `cargo doc --no-deps` and deploys them to GitHub Pages on every push to `main`. Update the `doc` and `doc-check` Makefile targets to use `--no-deps` to match.

### Why
Makes the API documentation publicly accessible without requiring users to build it locally.