### PR TITLE
Add commitment key secrecy as funder responsibility

### DIFF
--- a/contracts/channel/src/lib.rs
+++ b/contracts/channel/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ### Funder
 //!
-//! - None.
+//! - Keeping the commitment key secret.
 //!
 //! ### Recipient
 //!


### PR DESCRIPTION
### What
Documents that the funder is responsible for keeping the commitment key secret, replacing the previous "None" placeholder under the funder responsibilities section of the contract docs.

### Why
The commitment key's secrecy is a meaningful security requirement for correct channel operation, and omitting it left the documentation incomplete and potentially misleading to integrators.